### PR TITLE
move replay_init.sqf to function, keep script for compatibility

### DIFF
--- a/GRAD_replay_init.sqf
+++ b/GRAD_replay_init.sqf
@@ -1,37 +1,3 @@
-// idea from a script by austin_medic
-// completely reworked by nomisum for Gruppe Adler
-GRAD_REPLAY_DATABASE_LOCAL = [];
-GRAD_REPLAY_DATABASE_TARGET_COUNT_LOCAL = 999999; // something really high to prevent from finishing at once
-GRAD_REPLAY_PLAYBACK_PAUSED = false;
+//deprecated script to initialize module
 
-if (!isServer) exitWith {};
-
-params [["_precision", 1]];
-
-// constants
-GRAD_REPLAY_RECORDING_PAUSED = false;
-GRAD_REPLAY_RECORDING_STOPPED = false;
-
-GRAD_REPLAY_SENDING_DELAY = 0.1;
-
-GRAD_REPLAY_SIDES = [west, east, civilian, sideLogic, sideEmpty, sideUnknown, sideFriendly, sideEnemy];
-GRAD_REPLAY_EMPTY_TRACKED = true; // vehicle setVariable ["GRAD_replay_track", true];
-GRAD_REPLAY_CIVILIAN_TRAFFIC_TRACKED = false;
-GRAD_REPLAY_CIVILIAN_ONFOOT_TRACKED = false;
-
-GRAD_REPLAY_DATABASE_TEMP = [];
-GRAD_REPLAY_DATABASE = [];
-
-REPLAY_STEPS_PER_TICK = 1;
-
-[_precision] call GRAD_replay_fnc_startRecord;
-
-diag_log format ["grad replay: starting record"];
-
-
-
-/* to start playback:
-
-[] GRAD_replay_fnc_stopRecord;
-
-*/
+_this call GRAD_replay_fnc_init

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ arma3 in-game mission replay script (wip)
 records player movement and replays at end of mission
 
 call with
-`execVM "GRAD_replay_init.sqf";`
+`call GRAD_replay_fnc_init;`
 
 stop recording and replay with
 `call GRAD_replay_fnc_stopRecord;`

--- a/cfgFunctions.hpp
+++ b/cfgFunctions.hpp
@@ -31,6 +31,7 @@ class GRAD_replay {
 		file = MODULES_DIRECTORY\GRAD_replay\functions\server;
 
 		class getSideColor {};
+        class init {};
         class pauseRecord {};
         class preparePlaybackServer {};
         class setMeSpectator {};

--- a/functions/server/fn_init.sqf
+++ b/functions/server/fn_init.sqf
@@ -1,0 +1,37 @@
+// idea from a script by austin_medic
+// completely reworked by nomisum for Gruppe Adler
+GRAD_REPLAY_DATABASE_LOCAL = [];
+GRAD_REPLAY_DATABASE_TARGET_COUNT_LOCAL = 999999; // something really high to prevent from finishing at once
+GRAD_REPLAY_PLAYBACK_PAUSED = false;
+
+if (!isServer) exitWith {};
+
+params [["_precision", 1]];
+
+// constants
+GRAD_REPLAY_RECORDING_PAUSED = false;
+GRAD_REPLAY_RECORDING_STOPPED = false;
+
+GRAD_REPLAY_SENDING_DELAY = 0.1;
+
+GRAD_REPLAY_SIDES = [west, east, civilian, sideLogic, sideEmpty, sideUnknown, sideFriendly, sideEnemy];
+GRAD_REPLAY_EMPTY_TRACKED = true; // vehicle setVariable ["GRAD_replay_track", true];
+GRAD_REPLAY_CIVILIAN_TRAFFIC_TRACKED = false;
+GRAD_REPLAY_CIVILIAN_ONFOOT_TRACKED = false;
+
+GRAD_REPLAY_DATABASE_TEMP = [];
+GRAD_REPLAY_DATABASE = [];
+
+REPLAY_STEPS_PER_TICK = 1;
+
+[_precision] call GRAD_replay_fnc_startRecord;
+
+diag_log format ["grad replay: starting record"];
+
+
+
+/* to start playback:
+
+[] GRAD_replay_fnc_stopRecord;
+
+*/


### PR DESCRIPTION
Moves GRAD_replay_init.sqf to a function, so that you can call it with `[] call grad_replay_fnc_init` instead of the entire path to the module.

Keeps GRAD_replay_init.sqf file for backwards compatibility.