### PR TITLE
script initialization

### DIFF
--- a/functions/server/fn_init.sqf
+++ b/functions/server/fn_init.sqf
@@ -15,19 +15,33 @@ GRAD_REPLAY_DATABASE = [];
 
 // vehicle setVariable ["GRAD_replay_track", true];
 
-GRAD_REPLAY_SIDES = ([(missionConfigFile >> "GRAD_Replay"), "trackedSides", ["west", "east", "civilian"]] call BIS_fnc_returnConfigEntry) apply {call compile _x};
-GRAD_REPLAY_AI_VEHICLES_TRACKED = ([(missionConfigFile >> "GRAD_Replay"), "trackedVehicles", 0] call BIS_fnc_returnConfigEntry) == 1;
-GRAD_REPLAY_AI_ONFOOT_TRACKED = ([(missionConfigFile >> "GRAD_Replay"), "trackedAI", 0] call BIS_fnc_returnConfigEntry) == 1;
-REPLAY_STEPS_PER_TICK = [(missionConfigFile >> "GRAD_Replay"), "stepsPerTick", 1] call BIS_fnc_returnConfigEntry;
-GRAD_REPLAY_SENDING_CHUNK_SIZE = [(missionConfigFile >> "GRAD_Replay"), "sendingChunkSize", 10] call BIS_fnc_returnConfigEntry;
-GRAD_REPLAY_TRACKSHOTS = ([(missionConfigFile >> "GRAD_Replay"), "trackShots", 0] call BIS_fnc_returnConfigEntry) == 1;
-private _precision = [(missionConfigFile >> "GRAD_Replay"), "precision", 1] call BIS_fnc_returnConfigEntry;
+if (isNil "GRAD_REPLAY_SIDES") then {
+    GRAD_REPLAY_SIDES = ([(missionConfigFile >> "GRAD_Replay"), "trackedSides", ["west", "east", "civilian"]] call BIS_fnc_returnConfigEntry) apply {call compile _x};
+};
+if (isNil "GRAD_REPLAY_AI_VEHICLES_TRACKED") then {
+    GRAD_REPLAY_AI_VEHICLES_TRACKED = ([(missionConfigFile >> "GRAD_Replay"), "trackedVehicles", 0] call BIS_fnc_returnConfigEntry) == 1;
+};
+if (isNil "GRAD_REPLAY_AI_ONFOOT_TRACKED") then {
+    GRAD_REPLAY_AI_ONFOOT_TRACKED = ([(missionConfigFile >> "GRAD_Replay"), "trackedAI", 0] call BIS_fnc_returnConfigEntry) == 1;
+};
+if (isNil "REPLAY_STEPS_PER_TICK") then {
+    REPLAY_STEPS_PER_TICK = [(missionConfigFile >> "GRAD_Replay"), "stepsPerTick", 1] call BIS_fnc_returnConfigEntry;
+};
+if (isNil "GRAD_REPLAY_SENDING_CHUNK_SIZE") then {
+    GRAD_REPLAY_SENDING_CHUNK_SIZE = [(missionConfigFile >> "GRAD_Replay"), "sendingChunkSize", 10] call BIS_fnc_returnConfigEntry;
+};
+if (isNil "GRAD_REPLAY_TRACKSHOTS") then {
+    GRAD_REPLAY_TRACKSHOTS = ([(missionConfigFile >> "GRAD_Replay"), "trackShots", 0] call BIS_fnc_returnConfigEntry) == 1;
+};
+if (isNil "GRAD_REPLAY_PRECISION") then {
+    GRAD_REPLAY_PRECISION = [(missionConfigFile >> "GRAD_Replay"), "precision", 1] call BIS_fnc_returnConfigEntry;
+};
 
 if (GRAD_REPLAY_TRACKSHOTS) then {
     ["CAManBase","firedMan",{_this call grad_replay_fnc_onFiredMan}] call CBA_fnc_addClassEventHandler;
 };
 
-[_precision] call GRAD_replay_fnc_startRecord;
+[] call GRAD_replay_fnc_startRecord;
 
 /* to start playback:
 [] GRAD_replay_fnc_stopRecord;

--- a/functions/server/fn_startRecord.sqf
+++ b/functions/server/fn_startRecord.sqf
@@ -1,8 +1,6 @@
 #include "script_component.hpp"
 
-params ["_precision"];
-
-INFO_1("Starting recording with precision %1",_precision);
+INFO_1("Starting recording with precision %1",GRAD_REPLAY_PRECISION);
 
 {
     _x setVariable ["GRAD_replay_track", true];
@@ -112,4 +110,4 @@ private _currentSaveState = [];
     _nextTickData pushBack dayTime;
     GRAD_REPLAY_DATABASE pushBack _nextTickData;
 
-},_precision,[_currentSaveState]] call CBA_fnc_addPerFrameHandler;
+},GRAD_REPLAY_PRECISION,[_currentSaveState]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
If you want to set grad-replay settings by script (think mission params), currently they will be overwritten by grad_replay_fnc_init. This changes that.

Also adds the `GRAD_REPLAY_PRECISION` variable.