### PR TITLE
fix for zero divisor

### DIFF
--- a/functions/server/fn_startRecord.sqf
+++ b/functions/server/fn_startRecord.sqf
@@ -56,7 +56,7 @@ private _currentSaveState = [];
         if ([_unit,_veh,_isVehicle,_isEmptyVehicle,_isMan] call grad_replay_fnc_canTrackUnit) then {
 
             // set tracking ID if unit doesn't have one
-            _unitID = _unit getVariable "grad_replay_unitID";
+            private _unitID = _unit getVariable ["grad_replay_unitID",0];
             if (isNil "_unitID") then {
                 _unitID = _currentSaveState pushBack [];
                 _unit setVariable ["grad_replay_unitID",_unitID];


### PR DESCRIPTION
private _name = _unit >
 0:51:25   Error Zero divisor
 0:51:25 File node_modules\@gruppe-adler\replay\functions\server\fn_startRecord.sqf [GRAD_replay_fnc_startRecord], line 1815
 0:51:25 Error in expression <te _currentUnitData = _currentSaveState select _unitID;

(i think this is the fix)