### PR TITLE
save typeOf instead of icon --> get icon during assembly

### DIFF
--- a/functions/player/fn_assembleReplayData.sqf
+++ b/functions/player/fn_assembleReplayData.sqf
@@ -45,6 +45,13 @@ for [{_i=_startIndex},{_i< count GRAD_REPLAY_DATABASE_LOCAL},{_i=_i+1}] do {
                 _unitData = [];
                 _compressedUnitData = _x;
 
+                // replace typeOf with icon
+                _type = _compressedUnitData param [0,""];
+                if !(_type isEqualTo "") then {
+                    _compressedUnitData set [0,getText (configfile >> "CfgVehicles" >> _type >> "icon")];
+                };
+
+                // check if this unit has existing data states or if it is new
                 if (_forEachIndex >= count _currentUnitsDataStates) then {
                     _currentUnitsDataStates pushBack [];
                 };

--- a/functions/server/fn_startRecord.sqf
+++ b/functions/server/fn_startRecord.sqf
@@ -74,7 +74,6 @@ private _currentSaveState = [];
             _side = if (_isMan) then {side _unit} else {sideEmpty};
             _colorID = [_side] call GRAD_replay_fnc_getSideColorID;
             _type = typeOf _veh;
-            _icon = getText (configfile >> "CfgVehicles" >> _type >> "icon");
 
             // firedTarget is being set by fn_onFiredMan --> if it has a value, save and reset the variable
             _firedTarget = _unit getVariable ["grad_replay_firedTarget",[]];
@@ -102,7 +101,7 @@ private _currentSaveState = [];
                 };
             };
 
-            [_currentUnitData,_nextTickData,_unitID,[_icon,_colorID,_pos,_dir,_name,_groupname,_firedTarget]] call GRAD_replay_fnc_storeValue;
+            [_currentUnitData,_nextTickData,_unitID,[_type,_colorID,_pos,_dir,_name,_groupname,_firedTarget]] call GRAD_replay_fnc_storeValue;
         };
 
     } forEach _trackedUnits;

--- a/functions/server/fn_storeValue.sqf
+++ b/functions/server/fn_storeValue.sqf
@@ -2,12 +2,12 @@
 
 params [["_currentUnitData",[]],["_nextTickData",[]],["_unitID",-1],["_newUnitData",[]]];
 
-// _newUnitData contents: [_icon,_colorID,_pos,_dir,_name,_groupname]
+// _newUnitData contents: [_type,_colorID,_pos,_dir,_name,_groupname]
 if (count _newUnitData == 0) exitWith {};
 
 private _newSaveData = [];
 private _typeDefaults = [
-    "",         // icon
+    "",         // typeOf
     -1,         // color ID
     [0,0],      // pos2D
     -1,         // dir


### PR DESCRIPTION
Saves object's `typeOf` instead of icon. Replaces `typeOf` with icon during assembly. This way external tools, that don't have access to Arma's icons, can use the object's type to display a generic icon. (Zade and Willard have something cooking I hear.)

Edit: Tested and working.