### PR TITLE
fix #26 increase playback synchronization interval

### DIFF
--- a/functions/player/fn_startPlaybackClient.sqf
+++ b/functions/player/fn_startPlaybackClient.sqf
@@ -92,4 +92,4 @@ if (isMultiplayer && !(serverCommandAvailable "#kick")) exitWith {};
 
 [{
     [grad_replay_playbackPosition] remoteExec ["GRAD_replay_fnc_syncPlaybackPos", [0,-2] select isDedicated, false];
-},1,[]] call CBA_fnc_addPerFrameHandler;
+},10,[]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
Increases playback synchronization interval so replay will stutter less often. More of a workaround, actual fix would come in a playback rework that I have in mind.