### PR TITLE
improve shots tracking

### DIFF
--- a/functions/server/fn_onFiredMan.sqf
+++ b/functions/server/fn_onFiredMan.sqf
@@ -6,12 +6,11 @@ params ["_unit", "", "", "", "", "", "_projectile", "_vehicle"];
 _unit = effectiveCommander vehicle _unit;
 
 // make sure unit is being tracked
-private _unitID = _unit getVariable ["grad_replay_unitID",-1];
+private _unitID = _unit getVariable [QGVAR(unitID),-1];
 if (_unitID < 0) exitWith {};
 
 // a projectile is being tracked already
-if (_unit getVariable ["grad_replay_projectileTrackingRunning",false]) exitWith {};
-_unit setVariable ["grad_replay_projectileTrackingRunning",true];
+if (!isNil {_unit getVariable QGVAR(firedTarget)}) exitWith {};
 
 // track projectile
 private _lastProjectilePos = [0,0,0];
@@ -19,13 +18,14 @@ private _lastProjectilePos = [0,0,0];
     params ["_args","_handle"];
     _args params ["_projectile","_unit","_lastProjectilePos"];
 
+    if (!isNil {_unit getVariable QGVAR(firedTarget)}) exitWith {[_handle] call CBA_fnc_removePerFrameHandler};
+
     if (!isNull _projectile) then {
         _lastProjectilePos resize 0;
         _lastProjectilePos append (getPos _projectile);
     } else {
         _lastProjectilePos resize 2;
-        _unit setVariable ["grad_replay_firedTarget",_lastProjectilePos];
+        _unit setVariable [QGVAR(firedTarget),_lastProjectilePos];
         [_handle] call CBA_fnc_removePerFrameHandler;
-        _unit setVariable ["grad_replay_projectileTrackingRunning",false];
     };
 },0,[_projectile,_unit,_lastProjectilePos]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
Currently only the unit's first shot fired during a [save interval](https://github.com/gruppe-adler/grad-replay/blob/master/functions/server/fn_startRecord.sqf#L112) is being tracked. This changes that so that all shots are being tracked until the first tracking of the interval is complete - meaning the first shot to land will be the one being saved.

**Pros**
- if a tracked shot ricocheted in the old system, it would block all further shots from being tracked until it landed
- shots that are way off target and go kilometers through the air before landing are now more unlikely to be the ones that are being saved

**Cons**
- ~~worse performance, because multiple shots will be tracked simultaneously~~